### PR TITLE
Add device command execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,4 @@ The server exposes the following MCP tools:
 - `get_rooms` – return a mapping of room UUIDs to names.
 - `get_devices` – list devices with optional filtering.
 - `get_device_status` – fetch status for a device by UUID.
+- `execute_commands` – send commands to a device.

--- a/src/mcp_smartthings/api.py
+++ b/src/mcp_smartthings/api.py
@@ -289,3 +289,14 @@ class Location(ILocation):
         capabilities_df = pd.DataFrame(c, columns=['deviceId', 'component', 'capability', 'attribute', 'value', 'unit',
                                                    'timestamp'])
         return devices_df, capabilities_df
+
+    @retry(wait=wait_random_exponential(2), stop=stop_after_attempt(5))
+    def _device_commands(self, device_id: UUID | str, commands: list[dict]) -> dict:
+        """Low level API call to execute commands on a device."""
+        url = f"{BASE_URL}v1/devices/{device_id}/commands"
+        payload = {"commands": commands}
+        return self.session.post(url, json=payload).json()
+
+    def device_commands(self, device_id: UUID | str, commands: list[dict]) -> dict:
+        """Execute SmartThings commands on a device."""
+        return self._device_commands(device_id, commands)

--- a/src/mcp_smartthings/server.py
+++ b/src/mcp_smartthings/server.py
@@ -47,6 +47,12 @@ def get_device_status(device_id: UUID):
     return location._device_status(device_id)
 
 
+@mcp.tool(description="Execute commands on a device")
+def execute_commands(device_id: UUID, commands: List[dict]):
+    """Send SmartThings commands to a device."""
+    return location.device_commands(device_id, commands)
+
+
 if __name__ == "__main__":
     """Run the FastMCP server."""
     mcp.run()

--- a/test/test_api.py
+++ b/test/test_api.py
@@ -61,7 +61,7 @@ def test_get_devices_url(monkeypatch):
         "&category=Light"
         "&capabilitiesMode=or"
         "&includeRestricted=true"
-        "&roomId=r1"
+        f"&roomId={room1Id}"
         "&includeStatus=true"
         "&type=LAN"
     )
@@ -75,3 +75,23 @@ def test_get_devices_invalid(monkeypatch):
         loc.get_devices(capability="unknown")
     with pytest.raises(ValueError):
         loc.get_devices(room_id=noRoomId)
+
+
+def test_device_commands(monkeypatch):
+    loc = _make_location()
+
+    captured = {}
+
+    def fake_post(device_id, commands):
+        captured["device_id"] = device_id
+        captured["commands"] = commands
+        return {"status": "ok"}
+
+    loc._device_commands = fake_post
+
+    cmds = [{"component": "main", "capability": "switch", "command": "on", "arguments": []}]
+    res = loc.device_commands("dev1", cmds)
+
+    assert res == {"status": "ok"}
+    assert captured["device_id"] == "dev1"
+    assert captured["commands"] == cmds


### PR DESCRIPTION
## Summary
- support sending device commands via SmartThings API
- expose new `execute_commands` MCP tool
- document the new tool in the README
- test command execution helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b3b052ae8832b9b1308ec5f0ebe42