### PR TITLE
Add pre-commit config with bandit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+- repo: https://github.com/PyCQA/bandit
+  rev: '1.8.3'
+  hooks:
+  - id: bandit


### PR DESCRIPTION
## Summary
- add pre-commit config for Bandit security checks

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b4694f17c832b8712e0a7c9c920ea