### PR TITLE
Add integration tests for SmartThings API

### DIFF
--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -1,0 +1,31 @@
+import os
+import pytest
+
+from mcp_smartthings.api import Location
+
+TOKEN = os.getenv("TOKEN")
+
+pytestmark = pytest.mark.skipif(TOKEN is None, reason="TOKEN environment variable not set")
+
+
+def _get_location():
+    return Location(TOKEN)
+
+
+def test_fetch_devices():
+    loc = _get_location()
+    devices = loc.get_devices_short()
+    assert isinstance(devices, list)
+    assert devices, "no devices returned"
+    assert "deviceId" in devices[0]
+
+
+def test_event_history():
+    loc = _get_location()
+    devices = loc.get_devices_short()
+    if not devices:
+        pytest.skip("no devices available")
+    first_device_id = devices[0]["deviceId"]
+    history_df = loc.event_history(device_id=first_device_id, limit=1)
+    assert not history_df.empty
+    assert "deviceId" in history_df.columns


### PR DESCRIPTION
## Summary
- add integration tests for the SmartThings API that cover device fetch and history endpoints

## Testing
- `pip install -e .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684bb91e7808832b88683e2d7f6ed953