### PR TITLE
Fix history offset and add duration API

### DIFF
--- a/src/server.py
+++ b/src/server.py
@@ -95,38 +95,14 @@ def get_device_history(
     • If `delta_end` is not provided, it defaults to now.
 
     """
-    import time    
-    import isodate
-
-    epoch_time = int(time.time())
-
-    start_delta = isodate.parse_duration(delta_start)
-    start_s = epoch_time - int(start_delta.total_seconds())
-    
-    end_s = epoch_time
-    if delta_end is not None:
-        end_delta = isodate.parse_duration(delta_end)
-        end_s = epoch_time - int(end_delta.total_seconds())
-
-    start_ms = start_s * 1000  # Convert to milliseconds
-    end_ms = end_s * 1000
-
-    if room_id is not None:
-        return location.room_history(
-            room_id=room_id,
-            attribute=attribute,
-            start_ms=start_ms,
-            end_ms=end_ms,
-            granularity=granularity,
-            aggregate=aggregate,
-        )
-
-    return location.event_history(
+    return location.history(
         device_id=device_id,
+        room_id=room_id,
         attribute=attribute,
-        limit=500,
-        #paging_after_epoch=start_ms,
-        #paging_before_epoch=end_ms,
+        delta_start=delta_start,
+        delta_end=delta_end,
+        granularity=granularity,
+        aggregate=aggregate,
     )
 
 @mcp.tool(description="Get hub time")

--- a/test/test_integration.py
+++ b/test/test_integration.py
@@ -45,6 +45,16 @@ def test_room_history():
     assert "time" in history[0]
 
 
+def test_history_p30d():
+    loc = _get_location()
+    devices = loc.get_devices_short()
+    if not devices:
+        pytest.skip("no devices available")
+    first_device_id = devices[0]["deviceId"]
+    history = loc.history(device_id=first_device_id, attribute="temperature", delta_start="P30D")
+    assert history, "empty history for P30D"
+
+
 missing_attributes = {
     'temperatureRange',  'heatingSetpointRange', 'coolingSetpointRange', 
     'quantity', 'type', # battery 


### PR DESCRIPTION
## Summary
- move duration parsing into `Location`
- provide new `Location.history` method
- adjust server to use the new method
- add unit tests for history range calculation
- extend integration tests with 30‑day history check

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684ffd91b5e8832b9032e2c940d6492e